### PR TITLE
[WIP]chat-spaceのDBの設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,41 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+# chat-space DB設計
+## usersテーブル
+|Column|Type|Option|
+|------|----|------|
+|email|string|null: false, unique: true|
+|username|string|null: false, unique: true|
+|password|string|null: false|
+### Association
+- has_many :users_groups
+- has_many :groups,  through:  users_groups
+
+## groupsテーブル
+|Column|Type|Option|
+|------|----|------|
+|name|string|null: false, unique: true|
+### Association
+- has_many :users_groups
+- has_many :users,  through:  users_groups
+
+## users_groupsテーブル
+|Column|Type|Option|
+|------|----|------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group
+- has_many :messages
+
+## messagesテーブル
+|Column|Type|Option|
+|------|----|------|
+|body|text|null: false|
+|image|string|
+|user_group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user_group


### PR DESCRIPTION
# What
chat−spaceのDBの実装前のDBの設計をreadme記述すること。
usersテーブル、groupsテーブル、users_groupsテーブル、messagesテーブルの設計を記述した。

# Why
DBの実装前に設計することで、ミスを無くしスムーズにDBの実装に取り掛かれるため。